### PR TITLE
updated issues shield/link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contributions from the public are welcome.
 
 ### Using the issue tracker 💡
 
-The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/EdOverflow/security-txt.svg?style=flat-square)](https://github.com/EdOverflow/security-txt/issues)
+The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/securitytxt/security-txt.svg?style=flat-square)](https://github.com/securitytxt/security-txt/issues)
 
 ### Issues and labels 🏷
 


### PR DESCRIPTION
Just a minor change. Old issues shield/link pointed to the original repo under @EdOverflow's account. Updated to point to new repo/org home.