### PR TITLE
Fix Typo and Shield Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions from the public are welcome.
 
 ### Using the issue tracker 💡
 
-The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/EdOverflow/security-txt.svg?style=flat-square)](https://github.com/EdOverflow/security-txt/issues)
+The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/securitytxt/security-txt.svg?style=flat-square)](https://github.com/EdOverflow/security-txt/issues)
 
 ### Issues and labels 🏷
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions from the public are welcome.
 
 ### Using the issue tracker 💡
 
-The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/securitytxt/security-txt.svg?style=flat-square)](https://github.com/EdOverflow/security-txt/issues)
+The issue tracker is the preferred channel for bug reports and features requests. [![GitHub issues](https://img.shields.io/github/issues/securitytxt/security-txt.svg?style=flat-square)](https://github.com/securitytxt/security-txt/issues)
 
 ### Issues and labels 🏷
 

--- a/draft-foudil-securitytxt-01.txt
+++ b/draft-foudil-securitytxt-01.txt
@@ -165,7 +165,7 @@ Internet-Draft               INTERNET-DRAFT                  August 2017
    Contact: security@example.com
 
    # Our PGP key
-   Encryption: https://example.com/pgp-key.txtt
+   Encryption: https://example.com/pgp-key.txt
    <CODE ENDS>
 
 Foudil                  Expires February 20, 2018               [Page 3]


### PR DESCRIPTION
This pull request fixes the shield image and link at `CONTRIBUTING.md` and also fix a typo at the draft file (`.txtt.` to `.txt`).