### PR TITLE
Signature file should be added to the Well-Known URI's registry

### DIFF
--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -310,9 +310,10 @@ example.com is used in this document following the uses indicated in
 ## Well-Known URIs registry
 
 The "Well-Known URIs" registry should be updated with the following additional
-value (using the template from {{?RFC5785}}):
+values (using the template from {{?RFC5785}}):
 
 URI suffix: security.txt
+URI suffix: security.txt.sig
 
 Change controller: IETF
 


### PR DESCRIPTION
In accordance with issue #59, if the proposed "Signature" directive be officially included in a draft, then the proposed signature file "security.txt.sig" MUST also be added to the Well-Known URI's registry.  This pull request adds it to the draft RFC.