### PR TITLE
Make changes to the ABNF grammar for non-chainable directives

### DIFF
--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -732,8 +732,8 @@ sign-header      = &lt;headers and line from section 7 of [RFC4880]&gt;
 
 sign-footer      = &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
 
-unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
-unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
+unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
+unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -9,80 +9,30 @@
 
   
 <style type="text/css">/*<![CDATA[*/
-@viewport {
-  zoom: 1.0;
-  width: extend-to-zoom;
-}
-@-ms-viewport {
-  width: extend-to-zoom;
-  zoom: 1.0;
-}
-
-@media screen and (min-width: 1024px) {
-  body>ul.toc, body>#rfc\.toc {
-    position: fixed;
-    bottom: 0;
-    right: 0;
-    right: calc(50vw - 550px);
-    width: 300px;
-    z-index: 1;
-  }
-  #rfc\.toc {
-    top: 55px;
-    overflow: auto;
-    overscroll-behavior: contain;
-  }
-  ul.toc, #rfc\.toc {
-    overflow: auto;
-    overscroll-behavior: contain;
-  }
-  body>ul.toc {
-    top: 140px;
-  }
-
-  body {
-    padding-right: 350px;
-  }
-}
 
 body {
-  font: 16px "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font: 16px "Helvetica Neue","Open Sans",Helvetica,Calibri,sans-serif;
   color: #333;
   font-size-adjust: 0.5;
   line-height: 24px;
   margin: 75px auto;
-  max-width: 724px;
+  max-width: 624px;
+  padding: 0 5px;
 }
 
-.title, .filename, h1, h2, h3, h4 {
-  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+.title, .filename, h1, h2, h3, h4, h5 {
+  font: 16px "Roboto Condensed","Helvetica Neue","Open Sans",Helvetica,Calibri,sans-serif;
   font-size-adjust: 0.5;
-  font-weight: 500;
+  font-weight: bold;
   color: #333;
   line-height: 100%;
-  margin: 0.8em 0 0.3em;
+  margin: 1.2em 0 0.3em;
 }
-.title { font-size: 36px; }
-h1 { font-size: 36px; }
-h2 { font-size: 24px; }
-h3, h4 { font-size: 18px; }
+.title, #rfc\.title h1 { font-size: 32px; }
+h1, section h1, h2, section h2, section h3, nav h2 { font-size: 20px; }
+h3, section h4, h4, section h5 { font-size: 16px; }
 h1 a[href], h2 a[href], h3 a[href], h4 a[href] {
   color: #333;
-}
-
-ul.toc li {
-  list-style: none;
-  text-indent: -2.5em;
-  padding-left: 2.5em;
-  padding-bottom: 5px;
-  margin: 0;
-}
-ul.toc ul {
-  margin: 0;
-}
-/* xml2rfc nests ul directly inside ul which messes with the style badly */
-ul.toc, ul.toc>ul, ul.toc ul>ul {
-  margin: 0 0 0 1.5em;
 }
 
 table {
@@ -111,28 +61,30 @@ td.reference {
 }
 
 
-table.header {
+table.header, table#rfc\.headerblock {
   width: 100%;
 }
-table.header td {
+table.header td, table#rfc\.headerblock td {
   border: none;
   background-color: transparent;
   color: black;
+  padding: 0;
 }
 .filename {
+  display: block;
   color: rgb(119, 119, 119);
-  font-size: 23px;
+  font-size: 20px;
   font-weight: normal;
-  height: auto;
   line-height: 100%;
+  margin: 10px 0 32px;
 }
 #rfc\.abstract+p, #rfc\.abstract p {
-  font-size: 18px;
-  line-height: 27px%;
+  font-size: 20px;
+  line-height: 28px;
 }
 
-samp, tt, code, pre {
-  font: 11pt consolas, monospace;
+samp, tt, code, pre, span.tt {
+  font: 13.5px Consolas, monospace;
   font-size-adjust: none;
 }
 pre {
@@ -142,13 +94,15 @@ pre {
   padding: 5px;
   margin: 5px;
 }
-.figure {
+.figure, caption {
   font-style: italic;
   margin: 0 1.5em;
+  text-align: left;
 }
 
 address {
-  margin: 10px 0 0;
+  margin: 16px 2px;
+  line-height: 20px;
 }
 .vcard {
   font-style: normal;
@@ -156,8 +110,8 @@ address {
 .vcardline {
   display: block;
 }
-.vcardline .fn {
-  font-weight: bold;
+.vcardline .fn, address b {
+  font-weight: normal;
 }
 .vcardline .hidden {
   display: none;
@@ -211,15 +165,59 @@ a[href]:hover {
   background-color: #eee;
 }
 
-ol, ul, li, p {
+p, ol, ul, li {
   padding: 0;
-  margin: 0.5em 0 0.5em 2em;
 }
-li, p {
-  margin-left: 0;
+p {
+  margin: 0.5em 0;
+}
+ol, ul {
+  margin: 0.2em 0 0.2em 2em;
+}
+li {
+  margin: 0.2em 0;
 }
 address {
   font-style: normal;
+}
+
+ul.toc ul {
+  margin: 0 0 0 2em;
+}
+ul.toc li {
+  list-style: none;
+  margin: 0;
+}
+
+@media screen and (min-width: 924px) {
+  body {
+    padding-right: 350px;
+  }
+  body>ul.toc, body>#rfc\.toc {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    right: calc(50vw - 500px);
+    width: 300px;
+    z-index: 1;
+    overflow: auto;
+    overscroll-behavior: contain;
+  }
+  body>#rfc\.toc {
+    top: 55px;
+  }
+  body>ul.toc {
+    top: 100px;
+  }
+
+  ul.toc {
+    margin: 0 0 0 4px;
+    font-size: 12px;
+    line-height: 20px;
+  }
+  ul.toc ul {
+    margin-left: 1.2em;
+  }
 }
 
 .github-fork-ribbon-wrapper {
@@ -278,7 +276,8 @@ address {
   .github-fork-ribbon-wrapper {
     position: fixed;
   }
-/*]]>*/</style>
+  /*]]>*/</style>
+  <meta name="viewport" content="initial-scale=1.0">
 
 
   <link href="#rfc.toc" rel="Contents">
@@ -333,12 +332,12 @@ address {
 <link href="#rfc.authors" rel="Chapter">
 
 
-  <meta name="generator" content="xml2rfc version 2.16.0 - https://tools.ietf.org/tools/xml2rfc" />
+  <meta name="generator" content="xml2rfc version 2.22.3 - https://tools.ietf.org/tools/xml2rfc" />
   <link rel="schema.dct" href="http://purl.org/dc/terms/" />
 
   <meta name="dct.creator" content="Foudil, E. and Y. Shafranovich" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-foudil-securitytxt-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-04-08" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-04-17" />
   <meta name="dct.abstract" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
   <meta name="description" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
 
@@ -362,12 +361,12 @@ address {
 <td class="right">Y. Shafranovich</td>
 </tr>
 <tr>
-<td class="left">Expires: October 10, 2019</td>
+<td class="left">Expires: October 19, 2019</td>
 <td class="right">Nightwatch Cybersecurity</td>
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">April 08, 2019</td>
+<td class="right">April 17, 2019</td>
 </tr>
 
     	
@@ -383,7 +382,7 @@ address {
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on October 10, 2019.</p>
+<p>This Internet-Draft will expire on October 19, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -733,7 +732,8 @@ sign-header      = &lt;headers and line from section 7 of [RFC4880]&gt;
 
 sign-footer      = &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
 
-unsigned         = *line (canonical-field eol) (lang-field eol) *line
+unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
+unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -727,57 +727,57 @@ Version: GnuPG v1
 <p id="rfc.section.5.p.1">The expected file format of the security.txt file is plain text (MIME type &#8220;text/plain&#8221;) as defined in section 4.1.3 of <a href="#RFC2046" class="xref">[RFC2046]</a> and is encoded using UTF-8 <a href="#RFC3629" class="xref">[RFC3629]</a> in Net-Unicode form <a href="#RFC5198" class="xref">[RFC5198]</a>.</p>
 <p id="rfc.section.5.p.2">The following is an ABNF definition of the security.txt format, using the conventions defined in <a href="#RFC5234" class="xref">[RFC5234]</a>.</p>
 <pre>
-body             = signed / unsigned
+body             =  signed / unsigned
 
-signed           = sign-header unsigned sign-footer
+signed           =  sign-header unsigned sign-footer
 
-sign-header      = &lt;headers and line from section 7 of [RFC4880]&gt;
+sign-header      =  &lt;headers and line from section 7 of [RFC4880]&gt;
 
-sign-footer      = &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
+sign-footer      =  &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
 
-unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
 unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
-line             = (field / comment) eol
+line             =  (field / comment) eol
 
-eol              = *WSP [CR] LF
+eol              =  *WSP [CR] LF
 
-field            = ack-field /
-                   contact-field /
-                   encryption-field /                         
-                   hiring-field /
-                   policy-field /
-                   ext-field
+field            =  ack-field /
+                    contact-field /
+                    encryption-field /                         
+                    hiring-field /
+                    policy-field /
+                    ext-field
 
-fs               = ":"
+fs               =  ":"
 
-comment          = "#" *(WSP / VCHAR / %x80-FFFFF)
+comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-ack-field        = "Acknowledgments" fs SP uri
+ack-field        =  "Acknowledgments" fs SP uri
 
-canonical-field  = "Canonical" fs SP uri
+canonical-field  =  "Canonical" fs SP uri
 
-contact-field    = "Contact" fs SP uri
+contact-field    =  "Contact" fs SP uri
 
-lang-tag         = &lt;Language-Tag from section 2.1 of [RFC5646]&gt;
+lang-tag         =  &lt;Language-Tag from section 2.1 of [RFC5646]&gt;
 
-uri              = &lt;URI as per [RFC3986]&gt;
+uri              =  &lt;URI as per [RFC3986]&gt;
 
-encryption-field = "Encryption" fs SP uri
+encryption-field =  "Encryption" fs SP uri
 
-hiring-field     = "Hiring" fs SP uri
+hiring-field     =  "Hiring" fs SP uri
 
-policy-field     = "Policy" fs SP uri
+policy-field     =  "Policy" fs SP uri
 
-lang-field       = "Preferred-Languages" fs SP lang-values
+lang-field       =  "Preferred-Languages" fs SP lang-values
 
-lang-values      = lang-tag *("," [WSP] lang-tag)
+lang-values      =  lang-tag *("," [WSP] lang-tag)
 
-ext-field        = field-name fs SP unstructured
+ext-field        =  field-name fs SP unstructured
 
-field-name       = &lt;imported from section 3.6.8 of [RFC5322]&gt;
+field-name       =  &lt;imported from section 3.6.8 of [RFC5322]&gt;
 
-unstructured     = &lt;imported from section 3.2.5 of [RFC5322]&gt;
+unstructured     =  &lt;imported from section 3.2.5 of [RFC5322]&gt;
 </pre>
 <p id="rfc.section.5.p.3">&#8220;ext-field&#8221; refers to extension fields, which are discussed in <a href="#extensibility" class="xref">Section 4.4</a></p>
 <h1 id="rfc.section.6">

--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -338,7 +338,7 @@ ul.toc li {
 
   <meta name="dct.creator" content="Foudil, E. and Y. Shafranovich" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-foudil-securitytxt-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-04-17" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-04-19" />
   <meta name="dct.abstract" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
   <meta name="description" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
 
@@ -362,12 +362,12 @@ ul.toc li {
 <td class="right">Y. Shafranovich</td>
 </tr>
 <tr>
-<td class="left">Expires: October 19, 2019</td>
+<td class="left">Expires: October 21, 2019</td>
 <td class="right">Nightwatch Cybersecurity</td>
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">April 17, 2019</td>
+<td class="right">April 19, 2019</td>
 </tr>
 
     	
@@ -383,7 +383,7 @@ ul.toc li {
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on October 19, 2019.</p>
+<p>This Internet-Draft will expire on October 21, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -735,8 +735,8 @@ sign-header      = &lt;headers and line from section 7 of [RFC4880]&gt;
 
 sign-footer      = &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
 
-unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
-unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
+unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -329,6 +329,7 @@ ul.toc li {
 <link href="#rfc.appendix.B.4" rel="Chapter" title="B.4 Since draft-foudil-securitytxt-03">
 <link href="#rfc.appendix.B.5" rel="Chapter" title="B.5 Since draft-foudil-securitytxt-04">
 <link href="#rfc.appendix.B.6" rel="Chapter" title="B.6 Since draft-foudil-securitytxt-05">
+<link href="#rfc.appendix.B.7" rel="Chapter" title="B.7 Since draft-foudil-securitytxt-06">
 <link href="#rfc.authors" rel="Chapter">
 
 
@@ -487,6 +488,8 @@ ul.toc li {
 <li>B.5.   <a href="#rfc.appendix.B.5">Since draft-foudil-securitytxt-04</a>
 </li>
 <li>B.6.   <a href="#rfc.appendix.B.6">Since draft-foudil-securitytxt-05</a>
+</li>
+<li>B.7.   <a href="#rfc.appendix.B.7">Since draft-foudil-securitytxt-06</a>
 </li>
 </ul><li><a href="#rfc.authors">Authors' Addresses</a>
 </li>
@@ -1142,7 +1145,13 @@ unstructured     = &lt;imported from section 3.2.5 of [RFC5322]&gt;
 <li>Added language handling redirects (#143)</li>
 <li>Expanded security considerations section and fixed typos (#30, #73, #103, #112)</li>
 </ul>
-<p id="rfc.section.B.6.p.2">Full list of changes can be viewed via the IETF document tracker: https://tools.ietf.org/html/draft-foudil-securitytxt</p>
+<h1 id="rfc.appendix.B.7">
+<a href="#rfc.appendix.B.7">B.7.</a> <a href="#since-draft-foudil-securitytxt-06" id="since-draft-foudil-securitytxt-06">Since draft-foudil-securitytxt-06</a>
+</h1>
+<p></p>
+
+<ul><li>Fixed ABNF grammar for non-chainable directives (#150)</li></ul>
+<p id="rfc.section.B.7.p.2">Full list of changes can be viewed via the IETF document tracker: https://tools.ietf.org/html/draft-foudil-securitytxt</p>
 <h1 id="rfc.authors"><a href="#rfc.authors">Authors' Addresses</a></h1>
 <div class="avoidbreak">
   <address class="vcard">

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -413,57 +413,57 @@ The following is an ABNF definition of the security.txt format, using
 the conventions defined in {{!RFC5234}}.
 
 ~~~~~~~~~~
-body             = signed / unsigned
+body             =  signed / unsigned
 
-signed           = sign-header unsigned sign-footer
+signed           =  sign-header unsigned sign-footer
 
-sign-header      = <headers and line from section 7 of [RFC4880]>
+sign-header      =  <headers and line from section 7 of [RFC4880]>
 
-sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
+sign-footer      =  <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
 unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
-line             = (field / comment) eol
+line             =  (field / comment) eol
 
-eol              = *WSP [CR] LF
+eol              =  *WSP [CR] LF
 
-field            = ack-field /
-                   contact-field /
-                   encryption-field /                         
-                   hiring-field /
-                   policy-field /
-                   ext-field
+field            =  ack-field /
+                    contact-field /
+                    encryption-field /                         
+                    hiring-field /
+                    policy-field /
+                    ext-field
 
-fs               = ":"
+fs               =  ":"
 
-comment          = "#" *(WSP / VCHAR / %x80-FFFFF)
+comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-ack-field        = "Acknowledgments" fs SP uri
+ack-field        =  "Acknowledgments" fs SP uri
 
-canonical-field  = "Canonical" fs SP uri
+canonical-field  =  "Canonical" fs SP uri
 
-contact-field    = "Contact" fs SP uri
+contact-field    =  "Contact" fs SP uri
 
-lang-tag         = <Language-Tag from section 2.1 of [RFC5646]>
+lang-tag         =  <Language-Tag from section 2.1 of [RFC5646]>
 
-uri              = <URI as per [RFC3986]>
+uri              =  <URI as per [RFC3986]>
 
-encryption-field = "Encryption" fs SP uri
+encryption-field =  "Encryption" fs SP uri
 
-hiring-field     = "Hiring" fs SP uri
+hiring-field     =  "Hiring" fs SP uri
 
-policy-field     = "Policy" fs SP uri
+policy-field     =  "Policy" fs SP uri
 
-lang-field       = "Preferred-Languages" fs SP lang-values
+lang-field       =  "Preferred-Languages" fs SP lang-values
 
-lang-values      = lang-tag *("," [WSP] lang-tag)
+lang-values      =  lang-tag *("," [WSP] lang-tag)
 
-ext-field        = field-name fs SP unstructured
+ext-field        =  field-name fs SP unstructured
 
-field-name       = <imported from section 3.6.8 of [RFC5322]>
+field-name       =  <imported from section 3.6.8 of [RFC5322]>
 
-unstructured     = <imported from section 3.2.5 of [RFC5322]>
+unstructured     =  <imported from section 3.2.5 of [RFC5322]>
 ~~~~~~~~~~
 
 "ext-field" refers to extension fields, which are discussed in {{extensibility}}

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -421,7 +421,8 @@ sign-header      = <headers and line from section 7 of [RFC4880]>
 
 sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line (canonical-field eol) (lang-field eol) *line
+unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
+unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -421,8 +421,8 @@ sign-header      = <headers and line from section 7 of [RFC4880]>
 
 sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
-unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
+unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -741,5 +741,8 @@ of DNS-stored encryption keys (#28 and #94)
 - Added language handling redirects (#143)
 - Expanded security considerations section and fixed typos (#30, #73, #103, #112)
 
+## Since draft-foudil-securitytxt-06
+- Fixed ABNF grammar for non-chainable directives (#150)
+
 Full list of changes can be viewed via the IETF document tracker:
 https://tools.ietf.org/html/draft-foudil-securitytxt

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -421,8 +421,8 @@ sign-header      = <headers and line from section 7 of [RFC4880]>
 
 sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
-unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
+unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
+unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -5,8 +5,8 @@
 Network Working Group                                          E. Foudil
 Internet-Draft
 Intended status: Informational                           Y. Shafranovich
-Expires: October 19, 2019                       Nightwatch Cybersecurity
-                                                          April 17, 2019
+Expires: October 21, 2019                       Nightwatch Cybersecurity
+                                                          April 19, 2019
 
 
                    A Method for Web Security Policies
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on October 19, 2019.
+   This Internet-Draft will expire on October 21, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 1]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 1]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 2]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 2]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -165,7 +165,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 3]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 3]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -221,7 +221,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 4]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 4]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -277,7 +277,7 @@ https://[2001:db8:8:4::2]/.well-known/security.txt
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 5]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 5]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -333,7 +333,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 6]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 6]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -389,7 +389,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 7]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 7]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -445,7 +445,7 @@ Encryption: dns:5d2d37ab76d47d36._openpgpkey.example.com?type=OPENPGPKEY
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 8]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 8]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -501,7 +501,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019                [Page 9]
+Foudil & Shafranovich   Expires October 21, 2019                [Page 9]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -557,7 +557,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 10]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 10]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -582,8 +582,8 @@ sign-header      = <headers and line from section 7 of [RFC4880]>
 
 sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
-unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
+unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
 line             = (field / comment) eol
 
@@ -613,7 +613,7 @@ uri              = <URI as per [RFC3986]>
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 11]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 11]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -669,7 +669,7 @@ unstructured     = <imported from section 3.2.5 of [RFC5322]>
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 12]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 12]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -725,7 +725,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 13]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 13]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -781,7 +781,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 14]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 14]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -837,7 +837,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 15]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 15]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -893,7 +893,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 16]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 16]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -949,7 +949,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 17]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 17]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1005,7 +1005,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 18]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 18]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1061,7 +1061,7 @@ Appendix A.  Note to Readers
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 19]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 19]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1117,7 +1117,7 @@ B.2.  Since draft-foudil-securitytxt-01
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 20]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 20]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1173,7 +1173,7 @@ B.5.  Since draft-foudil-securitytxt-04
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 21]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 21]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1229,4 +1229,4 @@ Authors' Addresses
 
 
 
-Foudil & Shafranovich   Expires October 19, 2019               [Page 22]
+Foudil & Shafranovich   Expires October 21, 2019               [Page 22]

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -5,8 +5,8 @@
 Network Working Group                                          E. Foudil
 Internet-Draft
 Intended status: Informational                           Y. Shafranovich
-Expires: October 10, 2019                       Nightwatch Cybersecurity
-                                                          April 08, 2019
+Expires: October 19, 2019                       Nightwatch Cybersecurity
+                                                          April 17, 2019
 
 
                    A Method for Web Security Policies
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on October 10, 2019.
+   This Internet-Draft will expire on October 19, 2019.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 1]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 1]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 2]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 2]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -165,7 +165,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 3]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 3]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -221,7 +221,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 4]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 4]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -277,7 +277,7 @@ https://[2001:db8:8:4::2]/.well-known/security.txt
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 5]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 5]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -333,7 +333,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 6]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 6]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -389,7 +389,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 7]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 7]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -445,7 +445,7 @@ Encryption: dns:5d2d37ab76d47d36._openpgpkey.example.com?type=OPENPGPKEY
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 8]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 8]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -501,7 +501,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019                [Page 9]
+Foudil & Shafranovich   Expires October 19, 2019                [Page 9]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -557,7 +557,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 10]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 10]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -574,63 +574,65 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    The following is an ABNF definition of the security.txt format, using
    the conventions defined in [RFC5234].
 
-   body             = signed / unsigned
+body             = signed / unsigned
 
-   signed           = sign-header unsigned sign-footer
+signed           = sign-header unsigned sign-footer
 
-   sign-header      = <headers and line from section 7 of [RFC4880]>
+sign-header      = <headers and line from section 7 of [RFC4880]>
 
-   sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
+sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-   unsigned         = *line (canonical-field eol) (lang-field eol) *line
+unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
+unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
 
-   line             = (field / comment) eol
+line             = (field / comment) eol
 
-   eol              = *WSP [CR] LF
+eol              = *WSP [CR] LF
 
-   field            = ack-field /
-                      contact-field /
-                      encryption-field /
-                      hiring-field /
-                      policy-field /
-                      ext-field
+field            = ack-field /
+                   contact-field /
+                   encryption-field /
+                   hiring-field /
+                   policy-field /
+                   ext-field
 
-   fs               = ":"
+fs               = ":"
 
-   comment          = "#" *(WSP / VCHAR / %x80-FFFFF)
+comment          = "#" *(WSP / VCHAR / %x80-FFFFF)
 
-   ack-field        = "Acknowledgments" fs SP uri
+ack-field        = "Acknowledgments" fs SP uri
 
-   canonical-field  = "Canonical" fs SP uri
+canonical-field  = "Canonical" fs SP uri
 
-   contact-field    = "Contact" fs SP uri
+contact-field    = "Contact" fs SP uri
 
-   lang-tag         = <Language-Tag from section 2.1 of [RFC5646]>
+lang-tag         = <Language-Tag from section 2.1 of [RFC5646]>
 
-   uri              = <URI as per [RFC3986]>
-
-   encryption-field = "Encryption" fs SP uri
-
+uri              = <URI as per [RFC3986]>
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 11]
+
+
+Foudil & Shafranovich   Expires October 19, 2019               [Page 11]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
 
-   hiring-field     = "Hiring" fs SP uri
+encryption-field = "Encryption" fs SP uri
 
-   policy-field     = "Policy" fs SP uri
+hiring-field     = "Hiring" fs SP uri
 
-   lang-field       = "Preferred-Languages" fs SP lang-values
+policy-field     = "Policy" fs SP uri
 
-   lang-values      = lang-tag *("," [WSP] lang-tag)
+lang-field       = "Preferred-Languages" fs SP lang-values
 
-   ext-field        = field-name fs SP unstructured
+lang-values      = lang-tag *("," [WSP] lang-tag)
 
-   field-name       = <imported from section 3.6.8 of [RFC5322]>
+ext-field        = field-name fs SP unstructured
 
-   unstructured     = <imported from section 3.2.5 of [RFC5322]>
+field-name       = <imported from section 3.6.8 of [RFC5322]>
+
+unstructured     = <imported from section 3.2.5 of [RFC5322]>
 
    "ext-field" refers to extension fields, which are discussed in
    Section 4.4
@@ -663,16 +665,17 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
    If information and resources referenced in a "security.txt" file are
    incorrect or not kept up to date, this can result in security reports
-   not being received by the organization or sent to incorrect contacts,
-   thus exposing possible security issues to third parties.
 
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 12]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 12]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
+
+   not being received by the organization or sent to incorrect contacts,
+   thus exposing possible security issues to third parties.
 
    Organizations SHOULD ensure that information in this file and any
    referenced resources such as web pages, email addresses and telephone
@@ -722,10 +725,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-
-
-
-Foudil & Shafranovich   Expires October 10, 2019               [Page 13]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 13]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -781,7 +781,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 14]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 14]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -837,7 +837,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 15]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 15]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -893,7 +893,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 16]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 16]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -949,7 +949,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 17]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 17]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1005,7 +1005,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 18]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 18]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1061,7 +1061,7 @@ Appendix A.  Note to Readers
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 19]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 19]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1117,7 +1117,7 @@ B.2.  Since draft-foudil-securitytxt-01
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 20]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 20]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1173,7 +1173,7 @@ B.5.  Since draft-foudil-securitytxt-04
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 21]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 21]
 
 Internet-Draft     A Method for Web Security Policies         April 2019
 
@@ -1229,4 +1229,4 @@ Authors' Addresses
 
 
 
-Foudil & Shafranovich   Expires October 10, 2019               [Page 22]
+Foudil & Shafranovich   Expires October 19, 2019               [Page 22]

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -582,8 +582,8 @@ sign-header      = <headers and line from section 7 of [RFC4880]>
 
 sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line (canonical-field eol) *line (lang-field eol) *line
-unsigned        /= *line (lang-field eol) *line (canonical-field eol) *line
+unsigned         = *line [canonical-field eol] *line [lang-field eol] *line
+unsigned        /= *line [lang-field eol] *line [canonical-field eol] *line
 
 line             = (field / comment) eol
 

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -119,6 +119,7 @@ Internet-Draft     A Method for Web Security Policies         April 2019
      B.4.  Since draft-foudil-securitytxt-03 . . . . . . . . . . . .  21
      B.5.  Since draft-foudil-securitytxt-04 . . . . . . . . . . . .  21
      B.6.  Since draft-foudil-securitytxt-05 . . . . . . . . . . . .  22
+     B.7.  Since draft-foudil-securitytxt-06 . . . . . . . . . . . .  22
    Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  22
 
 1.  Introduction
@@ -157,7 +158,6 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    making it easier for organizations to designate the preferred steps
    for researchers to take when trying to reach out to them with
    security vulnerabilities.
-
 
 
 
@@ -1201,6 +1201,10 @@ B.6.  Since draft-foudil-securitytxt-05
    o  Expanded security considerations section and fixed typos (#30,
       #73, #103, #112)
 
+B.7.  Since draft-foudil-securitytxt-06
+
+   o  Fixed ABNF grammar for non-chainable directives (#150)
+
    Full list of changes can be viewed via the IETF document tracker:
    https://tools.ietf.org/html/draft-foudil-securitytxt
 
@@ -1215,10 +1219,6 @@ Authors' Addresses
    Nightwatch Cybersecurity
 
    Email: yakov+ietf@nightwatchcybersecurity.com
-
-
-
-
 
 
 

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -574,41 +574,41 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    The following is an ABNF definition of the security.txt format, using
    the conventions defined in [RFC5234].
 
-body             = signed / unsigned
+body             =  signed / unsigned
 
-signed           = sign-header unsigned sign-footer
+signed           =  sign-header unsigned sign-footer
 
-sign-header      = <headers and line from section 7 of [RFC4880]>
+sign-header      =  <headers and line from section 7 of [RFC4880]>
 
-sign-footer      = <OpenPGP signature from section 7 of [RFC4880]>
+sign-footer      =  <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         = *line [canonical-field eol *line] [lang-field eol] *line
+unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
 unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
 
-line             = (field / comment) eol
+line             =  (field / comment) eol
 
-eol              = *WSP [CR] LF
+eol              =  *WSP [CR] LF
 
-field            = ack-field /
-                   contact-field /
-                   encryption-field /
-                   hiring-field /
-                   policy-field /
-                   ext-field
+field            =  ack-field /
+                    contact-field /
+                    encryption-field /
+                    hiring-field /
+                    policy-field /
+                    ext-field
 
-fs               = ":"
+fs               =  ":"
 
-comment          = "#" *(WSP / VCHAR / %x80-FFFFF)
+comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-ack-field        = "Acknowledgments" fs SP uri
+ack-field        =  "Acknowledgments" fs SP uri
 
-canonical-field  = "Canonical" fs SP uri
+canonical-field  =  "Canonical" fs SP uri
 
-contact-field    = "Contact" fs SP uri
+contact-field    =  "Contact" fs SP uri
 
-lang-tag         = <Language-Tag from section 2.1 of [RFC5646]>
+lang-tag         =  <Language-Tag from section 2.1 of [RFC5646]>
 
-uri              = <URI as per [RFC3986]>
+uri              =  <URI as per [RFC3986]>
 
 
 
@@ -618,21 +618,21 @@ Foudil & Shafranovich   Expires October 21, 2019               [Page 11]
 Internet-Draft     A Method for Web Security Policies         April 2019
 
 
-encryption-field = "Encryption" fs SP uri
+encryption-field =  "Encryption" fs SP uri
 
-hiring-field     = "Hiring" fs SP uri
+hiring-field     =  "Hiring" fs SP uri
 
-policy-field     = "Policy" fs SP uri
+policy-field     =  "Policy" fs SP uri
 
-lang-field       = "Preferred-Languages" fs SP lang-values
+lang-field       =  "Preferred-Languages" fs SP lang-values
 
-lang-values      = lang-tag *("," [WSP] lang-tag)
+lang-values      =  lang-tag *("," [WSP] lang-tag)
 
-ext-field        = field-name fs SP unstructured
+ext-field        =  field-name fs SP unstructured
 
-field-name       = <imported from section 3.6.8 of [RFC5322]>
+field-name       =  <imported from section 3.6.8 of [RFC5322]>
 
-unstructured     = <imported from section 3.2.5 of [RFC5322]>
+unstructured     =  <imported from section 3.2.5 of [RFC5322]>
 
    "ext-field" refers to extension fields, which are discussed in
    Section 4.4


### PR DESCRIPTION
Resolves #150 

This pull request adds:
- Allow comments and fields in between a 'Canonical' field and a 'Preferred-Languages' field
- Allow a 'Canonical' field to appear after a 'Preferred-Languages' field (i.e,. make the order irrelevant)
- Allow a 'Canonical' field or 'Preferred-Languages' field to *not* appear (i.e., make them optional)
- Add a history entry

Questions:
- If a Canonical or Preferred-Languages field is ommitted, the grammar will effectively become `*line *line`. This, I think, will lead to a parsing ambiguity (i.e., which `*line` gobbles up more of the lines?), and is that bad (and is it avoidable)?
- If the file is signed, I believe 'Canonical' becomes a 'SHOULD'. Do we need to make it a requirement in the grammar or is that only for 'MUST's?
- It appears when I ran `make txt`, indentation for the ABNF section was lost. This is probably caused by a different version of the relevant tools, should I manually go in and re-indent all of the ABNF?