### PR TITLE
Make Contact required by simplifying ABNF

### DIFF
--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -78,13 +78,14 @@ table.header td, table#rfc\.headerblock td {
   line-height: 100%;
   margin: 10px 0 32px;
 }
-#rfc\.abstract+p, #rfc\.abstract p {
+#rfc\.abstract+p, #rfc\.abstract+p code, #rfc\.abstract+p samp, #rfc\.abstract+p tt {
   font-size: 20px;
   line-height: 28px;
 }
 
 samp, tt, code, pre, span.tt {
-  font: 13.5px Consolas, monospace;
+  font-size: 13.5px;
+  font-family: Consolas, monospace;
   font-size-adjust: none;
 }
 pre {
@@ -338,7 +339,7 @@ ul.toc li {
 
   <meta name="dct.creator" content="Foudil, E. and Y. Shafranovich" />
   <meta name="dct.identifier" content="urn:ietf:id:draft-foudil-securitytxt-06" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-04-19" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-05-03" />
   <meta name="dct.abstract" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
   <meta name="description" content="When security vulnerabilities are discovered by independent security researchers, they often lack the channels to report them properly. As a result, security vulnerabilities may be left unreported. This document defines a format (&#8220;security.txt&#8221;) to help organizations describe the process for security researchers to follow in order to report security vulnerabilities." />
 
@@ -362,12 +363,12 @@ ul.toc li {
 <td class="right">Y. Shafranovich</td>
 </tr>
 <tr>
-<td class="left">Expires: October 21, 2019</td>
+<td class="left">Expires: November 4, 2019</td>
 <td class="right">Nightwatch Cybersecurity</td>
 </tr>
 <tr>
 <td class="left"></td>
-<td class="right">April 19, 2019</td>
+<td class="right">May 03, 2019</td>
 </tr>
 
     	
@@ -383,7 +384,7 @@ ul.toc li {
 <p>This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.</p>
 <p>Internet-Drafts are working documents of the Internet Engineering Task Force (IETF).  Note that other groups may also distribute working documents as Internet-Drafts.  The list of current Internet-Drafts is at https://datatracker.ietf.org/drafts/current/.</p>
 <p>Internet-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use Internet-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This Internet-Draft will expire on October 21, 2019.</p>
+<p>This Internet-Draft will expire on November 4, 2019.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 IETF Trust and the persons identified as the document authors.  All rights reserved.</p>
 <p>This document is subject to BCP 78 and the IETF Trust's Legal Provisions Relating to IETF Documents (https://trustee.ietf.org/license-info) in effect on the date of publication of this document.  Please review these documents carefully, as they describe your rights and restrictions with respect to this document.  Code Components extracted from this document must include Simplified BSD License text as described in Section 4.e of the Trust Legal Provisions and are provided without warranty as described in the Simplified BSD License.</p>
@@ -727,57 +728,62 @@ Version: GnuPG v1
 <p id="rfc.section.5.p.1">The expected file format of the security.txt file is plain text (MIME type &#8220;text/plain&#8221;) as defined in section 4.1.3 of <a href="#RFC2046" class="xref">[RFC2046]</a> and is encoded using UTF-8 <a href="#RFC3629" class="xref">[RFC3629]</a> in Net-Unicode form <a href="#RFC5198" class="xref">[RFC5198]</a>.</p>
 <p id="rfc.section.5.p.2">The following is an ABNF definition of the security.txt format, using the conventions defined in <a href="#RFC5234" class="xref">[RFC5234]</a>.</p>
 <pre>
-body             =  signed / unsigned
+body                   =  signed / unsigned
 
-signed           =  sign-header unsigned sign-footer
+signed                 =  sign-header unsigned sign-footer
 
-sign-header      =  &lt;headers and line from section 7 of [RFC4880]&gt;
+sign-header            =  &lt;headers and line from section 7 of [RFC4880]&gt;
 
-sign-footer      =  &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
+sign-footer            =  &lt;OpenPGP signature from section 7 of [RFC4880]&gt;
 
-unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
-unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
+unsigned               =  *line &lt;in any order, but exactly once each: opt-canonical-line-etc, opt-lang-line-etc, contact-line-etc&gt;
 
-line             =  (field / comment) eol
+line                   =  (field / comment) eol
 
-eol              =  *WSP [CR] LF
+eol                    =  *WSP [CR] LF
 
-field            =  ack-field /
-                    contact-field /
-                    encryption-field /                         
-                    hiring-field /
-                    policy-field /
-                    ext-field
+field                  =  ack-field /
+                          contact-field /
+                          encryption-field /
+                          hiring-field /
+                          policy-field /
+                          ext-field
 
-fs               =  ":"
+opt-canonical-line-etc =  [canonical-field eol *line]
 
-comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
+opt-lang-line-etc      =  [lang-field eol *line]
 
-ack-field        =  "Acknowledgments" fs SP uri
+contact-line-etc       =  contact-field eol *line
 
-canonical-field  =  "Canonical" fs SP uri
+fs                     =  ":"
 
-contact-field    =  "Contact" fs SP uri
+comment                =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-lang-tag         =  &lt;Language-Tag from section 2.1 of [RFC5646]&gt;
+ack-field              =  "Acknowledgments" fs SP uri
 
-uri              =  &lt;URI as per [RFC3986]&gt;
+canonical-field        =  "Canonical" fs SP uri
 
-encryption-field =  "Encryption" fs SP uri
+contact-field          =  "Contact" fs SP uri
 
-hiring-field     =  "Hiring" fs SP uri
+lang-tag               =  &lt;Language-Tag from section 2.1 of [RFC5646]&gt;
 
-policy-field     =  "Policy" fs SP uri
+uri                    =  &lt;URI as per [RFC3986]&gt;
 
-lang-field       =  "Preferred-Languages" fs SP lang-values
+encryption-field       =  "Encryption" fs SP uri
 
-lang-values      =  lang-tag *("," [WSP] lang-tag)
+hiring-field           =  "Hiring" fs SP uri
 
-ext-field        =  field-name fs SP unstructured
+policy-field           =  "Policy" fs SP uri
 
-field-name       =  &lt;imported from section 3.6.8 of [RFC5322]&gt;
+lang-field             =  "Preferred-Languages" fs SP lang-values
 
-unstructured     =  &lt;imported from section 3.2.5 of [RFC5322]&gt;
+lang-values            =  lang-tag *("," [WSP] lang-tag)
+
+ext-field              =  field-name fs SP unstructured
+
+field-name             =  &lt;imported from section 3.6.8 of [RFC5322]&gt;
+
+unstructured           =  &lt;imported from section 3.2.5 of [RFC5322]&gt;
 </pre>
 <p id="rfc.section.5.p.3">&#8220;ext-field&#8221; refers to extension fields, which are discussed in <a href="#extensibility" class="xref">Section 4.4</a></p>
 <h1 id="rfc.section.6">

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -413,57 +413,62 @@ The following is an ABNF definition of the security.txt format, using
 the conventions defined in {{!RFC5234}}.
 
 ~~~~~~~~~~
-body             =  signed / unsigned
+body                   =  signed / unsigned
 
-signed           =  sign-header unsigned sign-footer
+signed                 =  sign-header unsigned sign-footer
 
-sign-header      =  <headers and line from section 7 of [RFC4880]>
+sign-header            =  <headers and line from section 7 of [RFC4880]>
 
-sign-footer      =  <OpenPGP signature from section 7 of [RFC4880]>
+sign-footer            =  <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
-unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
+unsigned               =  *line <in any order, but exactly once each: opt-canonical-line-etc, opt-lang-line-etc, contact-line-etc>
 
-line             =  (field / comment) eol
+line                   =  (field / comment) eol
 
-eol              =  *WSP [CR] LF
+eol                    =  *WSP [CR] LF
 
-field            =  ack-field /
-                    contact-field /
-                    encryption-field /                         
-                    hiring-field /
-                    policy-field /
-                    ext-field
+field                  =  ack-field /
+                          contact-field /
+                          encryption-field /
+                          hiring-field /
+                          policy-field /
+                          ext-field
 
-fs               =  ":"
+opt-canonical-line-etc =  [canonical-field eol *line]
 
-comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
+opt-lang-line-etc      =  [lang-field eol *line]
 
-ack-field        =  "Acknowledgments" fs SP uri
+contact-line-etc       =  contact-field eol *line
 
-canonical-field  =  "Canonical" fs SP uri
+fs                     =  ":"
 
-contact-field    =  "Contact" fs SP uri
+comment                =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-lang-tag         =  <Language-Tag from section 2.1 of [RFC5646]>
+ack-field              =  "Acknowledgments" fs SP uri
 
-uri              =  <URI as per [RFC3986]>
+canonical-field        =  "Canonical" fs SP uri
 
-encryption-field =  "Encryption" fs SP uri
+contact-field          =  "Contact" fs SP uri
 
-hiring-field     =  "Hiring" fs SP uri
+lang-tag               =  <Language-Tag from section 2.1 of [RFC5646]>
 
-policy-field     =  "Policy" fs SP uri
+uri                    =  <URI as per [RFC3986]>
 
-lang-field       =  "Preferred-Languages" fs SP lang-values
+encryption-field       =  "Encryption" fs SP uri
 
-lang-values      =  lang-tag *("," [WSP] lang-tag)
+hiring-field           =  "Hiring" fs SP uri
 
-ext-field        =  field-name fs SP unstructured
+policy-field           =  "Policy" fs SP uri
 
-field-name       =  <imported from section 3.6.8 of [RFC5322]>
+lang-field             =  "Preferred-Languages" fs SP lang-values
 
-unstructured     =  <imported from section 3.2.5 of [RFC5322]>
+lang-values            =  lang-tag *("," [WSP] lang-tag)
+
+ext-field              =  field-name fs SP unstructured
+
+field-name             =  <imported from section 3.6.8 of [RFC5322]>
+
+unstructured           =  <imported from section 3.2.5 of [RFC5322]>
 ~~~~~~~~~~
 
 "ext-field" refers to extension fields, which are discussed in {{extensibility}}

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -5,8 +5,8 @@
 Network Working Group                                          E. Foudil
 Internet-Draft
 Intended status: Informational                           Y. Shafranovich
-Expires: October 21, 2019                       Nightwatch Cybersecurity
-                                                          April 19, 2019
+Expires: November 4, 2019                       Nightwatch Cybersecurity
+                                                            May 03, 2019
 
 
                    A Method for Web Security Policies
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on October 21, 2019.
+   This Internet-Draft will expire on November 4, 2019.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Copyright Notice
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 1]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 1]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    the Trust Legal Provisions and are provided without warranty as
@@ -90,14 +90,14 @@ Table of Contents
    5.  File Format Description and ABNF Grammar  . . . . . . . . . .  11
    6.  Security Considerations . . . . . . . . . . . . . . . . . . .  12
      6.1.  Compromised Files and Redirects . . . . . . . . . . . . .  12
-     6.2.  Incorrect or Stale Information  . . . . . . . . . . . . .  12
+     6.2.  Incorrect or Stale Information  . . . . . . . . . . . . .  13
      6.3.  Intentionally Malformed Files, Resources and Reports  . .  13
      6.4.  No Implied Permission for Testing . . . . . . . . . . . .  13
      6.5.  Multi-user Environments . . . . . . . . . . . . . . . . .  13
      6.6.  Protecting Data in Transit  . . . . . . . . . . . . . . .  14
      6.7.  Spam and Spurious Reports . . . . . . . . . . . . . . . .  14
    7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  14
-     7.1.  Well-Known URIs registry  . . . . . . . . . . . . . . . .  14
+     7.1.  Well-Known URIs registry  . . . . . . . . . . . . . . . .  15
      7.2.  Registry for security.txt Header Fields . . . . . . . . .  15
    8.  Contributors  . . . . . . . . . . . . . . . . . . . . . . . .  16
    9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  17
@@ -109,9 +109,9 @@ Table of Contents
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 2]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 2]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
      B.2.  Since draft-foudil-securitytxt-01 . . . . . . . . . . . .  20
@@ -165,9 +165,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 3]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 3]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 1.2.  Terminology
@@ -221,9 +221,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 4]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 4]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    unlimited number of fields.  It is important to note that you MUST
@@ -277,9 +277,9 @@ https://[2001:db8:8:4::2]/.well-known/security.txt
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 5]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 5]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 3.3.  Separate Fields
@@ -333,9 +333,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 6]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 6]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 3.5.2.  Canonical
@@ -389,9 +389,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 7]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 7]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    When it comes to verifying the authenticity of the key, it is always
@@ -445,9 +445,9 @@ Encryption: dns:5d2d37ab76d47d36._openpgpkey.example.com?type=OPENPGPKEY
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 8]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 8]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    The order in which they appear MUST NOT be interpreted as an
@@ -501,9 +501,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019                [Page 9]
+Foudil & Shafranovich   Expires November 4, 2019                [Page 9]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 4.  Location of the security.txt file
@@ -557,9 +557,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 10]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 10]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    In general, implementors SHOULD "be conservative in what you do, be
@@ -574,65 +574,69 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    The following is an ABNF definition of the security.txt format, using
    the conventions defined in [RFC5234].
 
-body             =  signed / unsigned
+body                   =  signed / unsigned
 
-signed           =  sign-header unsigned sign-footer
+signed                 =  sign-header unsigned sign-footer
 
-sign-header      =  <headers and line from section 7 of [RFC4880]>
+sign-header            =  <headers and line from section 7 of [RFC4880]>
 
-sign-footer      =  <OpenPGP signature from section 7 of [RFC4880]>
+sign-footer            =  <OpenPGP signature from section 7 of [RFC4880]>
 
-unsigned         =  *line [canonical-field eol *line] [lang-field eol] *line
-unsigned         =/ *line [lang-field eol *line] [canonical-field eol] *line
+unsigned               =  *line <in any order, but exactly once each: opt-canonical-line-etc, opt-lang-line-etc, contact-line-etc>
 
-line             =  (field / comment) eol
+line                   =  (field / comment) eol
 
-eol              =  *WSP [CR] LF
+eol                    =  *WSP [CR] LF
 
-field            =  ack-field /
-                    contact-field /
-                    encryption-field /
-                    hiring-field /
-                    policy-field /
-                    ext-field
+field                  =  ack-field /
+                          contact-field /
+                          encryption-field /
+                          hiring-field /
+                          policy-field /
+                          ext-field
 
-fs               =  ":"
+opt-canonical-line-etc =  [canonical-field eol *line]
 
-comment          =  "#" *(WSP / VCHAR / %x80-FFFFF)
+opt-lang-line-etc      =  [lang-field eol *line]
 
-ack-field        =  "Acknowledgments" fs SP uri
+contact-line-etc       =  contact-field eol *line
 
-canonical-field  =  "Canonical" fs SP uri
+fs                     =  ":"
 
-contact-field    =  "Contact" fs SP uri
+comment                =  "#" *(WSP / VCHAR / %x80-FFFFF)
 
-lang-tag         =  <Language-Tag from section 2.1 of [RFC5646]>
+ack-field              =  "Acknowledgments" fs SP uri
 
-uri              =  <URI as per [RFC3986]>
+canonical-field        =  "Canonical" fs SP uri
+
+contact-field          =  "Contact" fs SP uri
 
 
 
-
-Foudil & Shafranovich   Expires October 21, 2019               [Page 11]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 11]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
-encryption-field =  "Encryption" fs SP uri
+lang-tag               =  <Language-Tag from section 2.1 of [RFC5646]>
 
-hiring-field     =  "Hiring" fs SP uri
+uri                    =  <URI as per [RFC3986]>
 
-policy-field     =  "Policy" fs SP uri
+encryption-field       =  "Encryption" fs SP uri
 
-lang-field       =  "Preferred-Languages" fs SP lang-values
+hiring-field           =  "Hiring" fs SP uri
 
-lang-values      =  lang-tag *("," [WSP] lang-tag)
+policy-field           =  "Policy" fs SP uri
 
-ext-field        =  field-name fs SP unstructured
+lang-field             =  "Preferred-Languages" fs SP lang-values
 
-field-name       =  <imported from section 3.6.8 of [RFC5322]>
+lang-values            =  lang-tag *("," [WSP] lang-tag)
 
-unstructured     =  <imported from section 3.2.5 of [RFC5322]>
+ext-field              =  field-name fs SP unstructured
+
+field-name             =  <imported from section 3.6.8 of [RFC5322]>
+
+unstructured           =  <imported from section 3.2.5 of [RFC5322]>
 
    "ext-field" refers to extension fields, which are discussed in
    Section 4.4
@@ -661,19 +665,19 @@ unstructured     =  <imported from section 3.2.5 of [RFC5322]>
    To avoid redirect attacks, redirects for these files MUST NOT be
    followed if they lead to a different domain (as per Section 4.1).
 
+
+
+
+
+Foudil & Shafranovich   Expires November 4, 2019               [Page 12]
+
+Internet-Draft     A Method for Web Security Policies           May 2019
+
+
 6.2.  Incorrect or Stale Information
 
    If information and resources referenced in a "security.txt" file are
    incorrect or not kept up to date, this can result in security reports
-
-
-
-
-Foudil & Shafranovich   Expires October 21, 2019               [Page 12]
-
-Internet-Draft     A Method for Web Security Policies         April 2019
-
-
    not being received by the organization or sent to incorrect contacts,
    thus exposing possible security issues to third parties.
 
@@ -718,17 +722,16 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    In multi-user / multi-tenant environments, it may possible for a user
    to take over the location of the "security.txt" file.  Organizations
    SHOULD reserve the "security.txt" namespace to ensure no third-party
+
+
+
+Foudil & Shafranovich   Expires November 4, 2019               [Page 13]
+
+Internet-Draft     A Method for Web Security Policies           May 2019
+
+
    can create a page with the "security.txt" AND "/.well-known/
    security.txt" names.
-
-
-
-
-
-Foudil & Shafranovich   Expires October 21, 2019               [Page 13]
-
-Internet-Draft     A Method for Web Security Policies         April 2019
-
 
 6.6.  Protecting Data in Transit
 
@@ -773,18 +776,20 @@ Internet-Draft     A Method for Web Security Policies         April 2019
    192.0.2.0 and 2001:db8:8:4::2 are used in this document following the
    uses indicated in [RFC6890].
 
+
+
+
+
+
+Foudil & Shafranovich   Expires November 4, 2019               [Page 14]
+
+Internet-Draft     A Method for Web Security Policies           May 2019
+
+
 7.1.  Well-Known URIs registry
 
    The "Well-Known URIs" registry should be updated with the following
    additional values (using the template from [RFC5785]):
-
-
-
-
-Foudil & Shafranovich   Expires October 21, 2019               [Page 14]
-
-Internet-Draft     A Method for Web Security Policies         April 2019
-
 
    URI suffix: security.txt
 
@@ -832,14 +837,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-
-
-
-
-
-Foudil & Shafranovich   Expires October 21, 2019               [Page 15]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 15]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    Field Name: Acknowledgments
@@ -893,9 +893,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 16]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 16]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    The authors would also like to acknowledge the feedback provided by
@@ -949,9 +949,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 17]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 17]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    [RFC5198]  Klensin, J. and M. Padlipsky, "Unicode Format for Network
@@ -1005,9 +1005,9 @@ Internet-Draft     A Method for Web Security Policies         April 2019
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 18]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 18]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 9.2.  Informative References
@@ -1061,9 +1061,9 @@ Appendix A.  Note to Readers
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 19]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 19]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 Appendix B.  Document History
@@ -1117,9 +1117,9 @@ B.2.  Since draft-foudil-securitytxt-01
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 20]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 20]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
 B.3.  Since draft-foudil-securitytxt-02
@@ -1173,9 +1173,9 @@ B.5.  Since draft-foudil-securitytxt-04
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 21]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 21]
 
-Internet-Draft     A Method for Web Security Policies         April 2019
+Internet-Draft     A Method for Web Security Policies           May 2019
 
 
    o  Removed permission directive (#30)
@@ -1229,4 +1229,4 @@ Authors' Addresses
 
 
 
-Foudil & Shafranovich   Expires October 21, 2019               [Page 22]
+Foudil & Shafranovich   Expires November 4, 2019               [Page 22]


### PR DESCRIPTION
Resolves #152 (and #151)

Use the "ignore whitespace" option for a nicer diff.

The naming convention I used was a little long, so I was wondering if you had any suggestions for shortening it.

- `opt` = optional
- `line` = terminated with an `eol`
- `etc` = 0 or more `line`s (trying to avoid an ambiguous grammar)

The idea is to keep everything in the angle brackets as simple as possible, so I didn't want to have a complicated chunk of ABNF there, just a list of production names.