### PR TITLE
Remove repeated ABNF field name

### DIFF
--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -457,7 +457,7 @@ policy-field     =  "Policy" fs SP uri
 
 lang-field       =  "Preferred-Languages" fs SP lang-values
 
-lang-values      =  lang-values = lang-tag *(*WSP "," *WSP lang-tag)
+lang-values      =  lang-tag *(*WSP "," *WSP lang-tag)
 
 ext-field        =  field-name fs SP unstructured
 


### PR DESCRIPTION
This is just a tiny tweak of the changes brought in by #166. Together with that pull request, this should fix #164.

These changes provide more flexibility in the use of white-space characters when defining preferred languages.