### PR TITLE
Remove demonstration for file system security.txt files

### DIFF
--- a/draft-foudil-securitytxt.html
+++ b/draft-foudil-securitytxt.html
@@ -18,21 +18,21 @@ to make it easier for researchers to report vulnerabilities.
 <meta content="draft-foudil-securitytxt-10" name="ietf.draft">
 <!-- Generator version information:
   xml2rfc 3.5.0
-    Python 3.9.0
+    Python 3.6.9
     appdirs 1.4.4
-    ConfigArgParse 1.2.3
+    ConfigArgParse 1.3
     google-i18n-address 2.4.0
     html5lib 1.1
-    intervaltree 3.1.0
-    Jinja2 2.11.2
+    intervaltree 2.1.0
+    Jinja2 2.11.3
     kitchen 1.2.6
-    lxml 4.6.2
+    lxml 4.2.1
     pycountry 20.7.3
-    pyflakes 2.2.0
-    PyYAML 5.3.1
-    requests 2.24.0
-    setuptools 50.3.2
-    six 1.15.0
+    pyflakes 1.6.0
+    PyYAML 5.4.1
+    requests 2.18.4
+    setuptools 39.0.1
+    six 1.11.0
 -->
 <link href="draft-foudil-securitytxt.xml" rel="alternate" type="application/rfc+xml">
 <link href="#copyright" rel="license">
@@ -826,7 +826,7 @@ address div.right {
 </tr></thead>
 <tfoot><tr>
 <td class="left">Foudil &amp; Shafranovich</td>
-<td class="center">Expires 28 August 2021</td>
+<td class="center">Expires 29 August 2021</td>
 <td class="right">[Page]</td>
 </tr></tfoot>
 </table>
@@ -839,12 +839,12 @@ address div.right {
 <dd class="internet-draft">draft-foudil-securitytxt-10</dd>
 <dt class="label-published">Published:</dt>
 <dd class="published">
-<time datetime="2021-02-24" class="published">24 February 2021</time>
+<time datetime="2021-02-25" class="published">25 February 2021</time>
     </dd>
 <dt class="label-intended-status">Intended Status:</dt>
 <dd class="intended-status">Informational</dd>
 <dt class="label-expires">Expires:</dt>
-<dd class="expires"><time datetime="2021-08-28">28 August 2021</time></dd>
+<dd class="expires"><time datetime="2021-08-29">29 August 2021</time></dd>
 <dt class="label-authors">Authors:</dt>
 <dd class="authors">
 <div class="author">
@@ -885,7 +885,7 @@ to make it easier for researchers to report vulnerabilities.<a href="#section-ab
         time. It is inappropriate to use Internet-Drafts as reference
         material or to cite them other than as "work in progress."<a href="#section-boilerplate.1-3" class="pilcrow">¶</a></p>
 <p id="section-boilerplate.1-4">
-        This Internet-Draft will expire on 28 August 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
+        This Internet-Draft will expire on 29 August 2021.<a href="#section-boilerplate.1-4" class="pilcrow">¶</a></p>
 </section>
 </div>
 <div id="copyright">
@@ -913,180 +913,180 @@ to make it easier for researchers to report vulnerabilities.<a href="#section-ab
         <a href="#" onclick="scroll(0,0)" class="toplink">▲</a><h2 id="name-table-of-contents">
 <a href="#name-table-of-contents" class="section-name selfRef">Table of Contents</a>
         </h2>
-<nav class="toc"><ul class="ulEmpty toc compact">
-<li class="ulEmpty toc compact" id="section-toc.1-1.1">
+<nav class="toc"><ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.1">
             <p id="section-toc.1-1.1.1" class="keepWithNext"><a href="#section-1" class="xref">1</a>.  <a href="#name-introduction" class="xref">Introduction</a><a href="#section-toc.1-1.1.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.1.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.1.2.1">
                 <p id="section-toc.1-1.1.2.1.1" class="keepWithNext"><a href="#section-1.1" class="xref">1.1</a>.  <a href="#name-motivation-prior-work-and-s" class="xref">Motivation, Prior Work and Scope</a><a href="#section-toc.1-1.1.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.1.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.1.2.2">
                 <p id="section-toc.1-1.1.2.2.1" class="keepWithNext"><a href="#section-1.2" class="xref">1.2</a>.  <a href="#name-terminology" class="xref">Terminology</a><a href="#section-toc.1-1.1.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.2">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.2">
             <p id="section-toc.1-1.2.1"><a href="#section-2" class="xref">2</a>.  <a href="#name-note-to-readers" class="xref">Note to Readers</a><a href="#section-toc.1-1.2.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.3">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.3">
             <p id="section-toc.1-1.3.1"><a href="#section-3" class="xref">3</a>.  <a href="#name-the-specification" class="xref">The Specification</a><a href="#section-toc.1-1.3.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.3.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.3.2.1">
                 <p id="section-toc.1-1.3.2.1.1"><a href="#section-3.1" class="xref">3.1</a>.  <a href="#name-comments" class="xref">Comments</a><a href="#section-toc.1-1.3.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.2">
                 <p id="section-toc.1-1.3.2.2.1"><a href="#section-3.2" class="xref">3.2</a>.  <a href="#name-line-separator" class="xref">Line Separator</a><a href="#section-toc.1-1.3.2.2.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.3">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.3">
                 <p id="section-toc.1-1.3.2.3.1"><a href="#section-3.3" class="xref">3.3</a>.  <a href="#name-digital-signature" class="xref">Digital signature</a><a href="#section-toc.1-1.3.2.3.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.4">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.4">
                 <p id="section-toc.1-1.3.2.4.1"><a href="#section-3.4" class="xref">3.4</a>.  <a href="#name-extensibility" class="xref">Extensibility</a><a href="#section-toc.1-1.3.2.4.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5">
                 <p id="section-toc.1-1.3.2.5.1"><a href="#section-3.5" class="xref">3.5</a>.  <a href="#name-field-definitions" class="xref">Field Definitions</a><a href="#section-toc.1-1.3.2.5.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.1">
                     <p id="section-toc.1-1.3.2.5.2.1.1"><a href="#section-3.5.1" class="xref">3.5.1</a>.  <a href="#name-acknowledgments" class="xref">Acknowledgments</a><a href="#section-toc.1-1.3.2.5.2.1.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.2">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.2">
                     <p id="section-toc.1-1.3.2.5.2.2.1"><a href="#section-3.5.2" class="xref">3.5.2</a>.  <a href="#name-canonical" class="xref">Canonical</a><a href="#section-toc.1-1.3.2.5.2.2.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.3">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.3">
                     <p id="section-toc.1-1.3.2.5.2.3.1"><a href="#section-3.5.3" class="xref">3.5.3</a>.  <a href="#name-contact" class="xref">Contact</a><a href="#section-toc.1-1.3.2.5.2.3.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.4">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.4">
                     <p id="section-toc.1-1.3.2.5.2.4.1"><a href="#section-3.5.4" class="xref">3.5.4</a>.  <a href="#name-encryption" class="xref">Encryption</a><a href="#section-toc.1-1.3.2.5.2.4.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.5">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.5">
                     <p id="section-toc.1-1.3.2.5.2.5.1"><a href="#section-3.5.5" class="xref">3.5.5</a>.  <a href="#name-expires" class="xref">Expires</a><a href="#section-toc.1-1.3.2.5.2.5.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.6">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.6">
                     <p id="section-toc.1-1.3.2.5.2.6.1"><a href="#section-3.5.6" class="xref">3.5.6</a>.  <a href="#name-hiring" class="xref">Hiring</a><a href="#section-toc.1-1.3.2.5.2.6.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.7">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.7">
                     <p id="section-toc.1-1.3.2.5.2.7.1"><a href="#section-3.5.7" class="xref">3.5.7</a>.  <a href="#name-policy" class="xref">Policy</a><a href="#section-toc.1-1.3.2.5.2.7.1" class="pilcrow">¶</a></p>
 </li>
-                  <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.5.2.8">
+                  <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.5.2.8">
                     <p id="section-toc.1-1.3.2.5.2.8.1"><a href="#section-3.5.8" class="xref">3.5.8</a>.  <a href="#name-preferred-languages" class="xref">Preferred-Languages</a><a href="#section-toc.1-1.3.2.5.2.8.1" class="pilcrow">¶</a></p>
 </li>
                 </ul>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.6">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.6">
                 <p id="section-toc.1-1.3.2.6.1"><a href="#section-3.6" class="xref">3.6</a>.  <a href="#name-example-of-an-unsigned-secu" class="xref">Example of an unsigned "security.txt" file</a><a href="#section-toc.1-1.3.2.6.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.3.2.7">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.3.2.7">
                 <p id="section-toc.1-1.3.2.7.1"><a href="#section-3.7" class="xref">3.7</a>.  <a href="#name-example-of-a-signed-securit" class="xref">Example of a signed "security.txt" file</a><a href="#section-toc.1-1.3.2.7.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.4">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.4">
             <p id="section-toc.1-1.4.1"><a href="#section-4" class="xref">4</a>.  <a href="#name-location-of-the-securitytxt" class="xref">Location of the security.txt file</a><a href="#section-toc.1-1.4.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.4.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.4.2.1">
                 <p id="section-toc.1-1.4.2.1.1"><a href="#section-4.1" class="xref">4.1</a>.  <a href="#name-scope-of-the-file" class="xref">Scope of the File</a><a href="#section-toc.1-1.4.2.1.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.5">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.5">
             <p id="section-toc.1-1.5.1"><a href="#section-5" class="xref">5</a>.  <a href="#name-file-format-description-and" class="xref">File Format Description and ABNF Grammar</a><a href="#section-toc.1-1.5.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.6">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.6">
             <p id="section-toc.1-1.6.1"><a href="#section-6" class="xref">6</a>.  <a href="#name-security-considerations" class="xref">Security Considerations</a><a href="#section-toc.1-1.6.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.6.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.6.2.1">
                 <p id="section-toc.1-1.6.2.1.1"><a href="#section-6.1" class="xref">6.1</a>.  <a href="#name-compromised-files-and-incid" class="xref">Compromised Files and Incident Response</a><a href="#section-toc.1-1.6.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.2">
                 <p id="section-toc.1-1.6.2.2.1"><a href="#section-6.2" class="xref">6.2</a>.  <a href="#name-redirects" class="xref">Redirects</a><a href="#section-toc.1-1.6.2.2.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.3">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.3">
                 <p id="section-toc.1-1.6.2.3.1"><a href="#section-6.3" class="xref">6.3</a>.  <a href="#name-incorrect-or-stale-informat" class="xref">Incorrect or Stale Information</a><a href="#section-toc.1-1.6.2.3.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.4">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.4">
                 <p id="section-toc.1-1.6.2.4.1"><a href="#section-6.4" class="xref">6.4</a>.  <a href="#name-intentionally-malformed-fil" class="xref">Intentionally Malformed Files, Resources and Reports</a><a href="#section-toc.1-1.6.2.4.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.5">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.5">
                 <p id="section-toc.1-1.6.2.5.1"><a href="#section-6.5" class="xref">6.5</a>.  <a href="#name-no-implied-permission-for-t" class="xref">No Implied Permission for Testing</a><a href="#section-toc.1-1.6.2.5.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.6">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.6">
                 <p id="section-toc.1-1.6.2.6.1"><a href="#section-6.6" class="xref">6.6</a>.  <a href="#name-multi-user-environments" class="xref">Multi-user Environments</a><a href="#section-toc.1-1.6.2.6.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.7">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.7">
                 <p id="section-toc.1-1.6.2.7.1"><a href="#section-6.7" class="xref">6.7</a>.  <a href="#name-protecting-data-in-transit" class="xref">Protecting Data in Transit</a><a href="#section-toc.1-1.6.2.7.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.6.2.8">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.6.2.8">
                 <p id="section-toc.1-1.6.2.8.1"><a href="#section-6.8" class="xref">6.8</a>.  <a href="#name-spam-and-spurious-reports" class="xref">Spam and Spurious Reports</a><a href="#section-toc.1-1.6.2.8.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.7">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.7">
             <p id="section-toc.1-1.7.1"><a href="#section-7" class="xref">7</a>.  <a href="#name-iana-considerations" class="xref">IANA Considerations</a><a href="#section-toc.1-1.7.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.7.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.7.2.1">
                 <p id="section-toc.1-1.7.2.1.1"><a href="#section-7.1" class="xref">7.1</a>.  <a href="#name-well-known-uris-registry" class="xref">Well-Known URIs registry</a><a href="#section-toc.1-1.7.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.7.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.7.2.2">
                 <p id="section-toc.1-1.7.2.2.1"><a href="#section-7.2" class="xref">7.2</a>.  <a href="#name-registry-for-securitytxt-fi" class="xref">Registry for security.txt Fields</a><a href="#section-toc.1-1.7.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.8">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.8">
             <p id="section-toc.1-1.8.1"><a href="#section-8" class="xref">8</a>.  <a href="#name-contributors" class="xref">Contributors</a><a href="#section-toc.1-1.8.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.9">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.9">
             <p id="section-toc.1-1.9.1"><a href="#section-9" class="xref">9</a>.  <a href="#name-references" class="xref">References</a><a href="#section-toc.1-1.9.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.9.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.9.2.1">
                 <p id="section-toc.1-1.9.2.1.1"><a href="#section-9.1" class="xref">9.1</a>.  <a href="#name-normative-references" class="xref">Normative References</a><a href="#section-toc.1-1.9.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.9.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.9.2.2">
                 <p id="section-toc.1-1.9.2.2.1"><a href="#section-9.2" class="xref">9.2</a>.  <a href="#name-informative-references" class="xref">Informative References</a><a href="#section-toc.1-1.9.2.2.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.10">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.10">
             <p id="section-toc.1-1.10.1"><a href="#section-appendix.a" class="xref">Appendix A</a>.  <a href="#name-note-to-readers-2" class="xref">Note to Readers</a><a href="#section-toc.1-1.10.1" class="pilcrow">¶</a></p>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.11">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.11">
             <p id="section-toc.1-1.11.1"><a href="#section-appendix.b" class="xref">Appendix B</a>.  <a href="#name-document-history" class="xref">Document History</a><a href="#section-toc.1-1.11.1" class="pilcrow">¶</a></p>
-<ul class="ulEmpty compact toc">
-<li class="ulEmpty compact toc" id="section-toc.1-1.11.2.1">
+<ul class="compact ulEmpty toc">
+<li class="compact ulEmpty toc" id="section-toc.1-1.11.2.1">
                 <p id="section-toc.1-1.11.2.1.1"><a href="#section-b.1" class="xref">B.1</a>.  <a href="#name-since-draft-foudil-security" class="xref">Since draft-foudil-securitytxt-00</a><a href="#section-toc.1-1.11.2.1.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.2">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.2">
                 <p id="section-toc.1-1.11.2.2.1"><a href="#section-b.2" class="xref">B.2</a>.  <a href="#name-since-draft-foudil-securityt" class="xref">Since draft-foudil-securitytxt-01</a><a href="#section-toc.1-1.11.2.2.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.3">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.3">
                 <p id="section-toc.1-1.11.2.3.1"><a href="#section-b.3" class="xref">B.3</a>.  <a href="#name-since-draft-foudil-securitytx" class="xref">Since draft-foudil-securitytxt-02</a><a href="#section-toc.1-1.11.2.3.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.4">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.4">
                 <p id="section-toc.1-1.11.2.4.1"><a href="#section-b.4" class="xref">B.4</a>.  <a href="#name-since-draft-foudil-securitytxt" class="xref">Since draft-foudil-securitytxt-03</a><a href="#section-toc.1-1.11.2.4.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.5">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.5">
                 <p id="section-toc.1-1.11.2.5.1"><a href="#section-b.5" class="xref">B.5</a>.  <a href="#name-since-draft-foudil-securitytxt-" class="xref">Since draft-foudil-securitytxt-04</a><a href="#section-toc.1-1.11.2.5.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.6">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.6">
                 <p id="section-toc.1-1.11.2.6.1"><a href="#section-b.6" class="xref">B.6</a>.  <a href="#name-since-draft-foudil-securitytxt-0" class="xref">Since draft-foudil-securitytxt-05</a><a href="#section-toc.1-1.11.2.6.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.7">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.7">
                 <p id="section-toc.1-1.11.2.7.1"><a href="#section-b.7" class="xref">B.7</a>.  <a href="#name-since-draft-foudil-securitytxt-06" class="xref">Since draft-foudil-securitytxt-06</a><a href="#section-toc.1-1.11.2.7.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.8">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.8">
                 <p id="section-toc.1-1.11.2.8.1"><a href="#section-b.8" class="xref">B.8</a>.  <a href="#name-since-draft-foudil-securitytxt-07" class="xref">Since draft-foudil-securitytxt-07</a><a href="#section-toc.1-1.11.2.8.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.9">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.9">
                 <p id="section-toc.1-1.11.2.9.1"><a href="#section-b.9" class="xref">B.9</a>.  <a href="#name-since-draft-foudil-securitytxt-08" class="xref">Since draft-foudil-securitytxt-08</a><a href="#section-toc.1-1.11.2.9.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.10">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.10">
                 <p id="section-toc.1-1.11.2.10.1"><a href="#section-b.10" class="xref">B.10</a>. <a href="#name-since-draft-foudil-securitytxt-09" class="xref">Since draft-foudil-securitytxt-09</a><a href="#section-toc.1-1.11.2.10.1" class="pilcrow">¶</a></p>
 </li>
-              <li class="ulEmpty compact toc" id="section-toc.1-1.11.2.11">
+              <li class="compact ulEmpty toc" id="section-toc.1-1.11.2.11">
                 <p id="section-toc.1-1.11.2.11.1"><a href="#section-b.11" class="xref">B.11</a>. <a href="#name-since-draft-foudil-securitytxt-1" class="xref">Since draft-foudil-securitytxt-10</a><a href="#section-toc.1-1.11.2.11.1" class="pilcrow">¶</a></p>
 </li>
             </ul>
 </li>
-          <li class="ulEmpty toc compact" id="section-toc.1-1.12">
+          <li class="compact ulEmpty toc" id="section-toc.1-1.12">
             <p id="section-toc.1-1.12.1"><a href="#section-appendix.c" class="xref"></a><a href="#name-authors-addresses" class="xref">Authors' Addresses</a><a href="#section-toc.1-1.12.1" class="pilcrow">¶</a></p>
 </li>
         </ul>
@@ -1545,9 +1545,6 @@ https://192.0.2.0/.well-known/security.txt
 
 # This security.txt file applies to IPv6 address of 2001:db8:8:4::2.
 https://[2001:db8:8:4::2]/.well-known/security.txt
-
-# This file applies to the /example/folder1 directory and subfolders.
-/example/folder1/security.txt
 </pre><a href="#section-4.1-5" class="pilcrow">¶</a>
 </div>
 </section>
@@ -2331,7 +2328,7 @@ of DNS-stored encryption keys (#28 and #94)<a href="#section-b.3-1.8" class="pil
 <ul class="normal">
 <li class="normal" id="section-b.11-1.1">Changes addressing IESG feedback<a href="#section-b.11-1.1" class="pilcrow">¶</a>
 </li>
-          <li class="normal" id="section-b.11-1.2">Removed languages regarding file systems (#201)<a href="#section-b.11-1.2" class="pilcrow">¶</a>
+          <li class="normal" id="section-b.11-1.2">Removed language regarding file systems (#201)<a href="#section-b.11-1.2" class="pilcrow">¶</a>
 </li>
         </ul>
 <p id="section-b.11-2">Full list of changes can be viewed via the IETF document tracker:

--- a/draft-foudil-securitytxt.md
+++ b/draft-foudil-securitytxt.md
@@ -419,9 +419,6 @@ https://192.0.2.0/.well-known/security.txt
 
 # This security.txt file applies to IPv6 address of 2001:db8:8:4::2.
 https://[2001:db8:8:4::2]/.well-known/security.txt
-
-# This file applies to the /example/folder1 directory and subfolders.
-/example/folder1/security.txt
 ~~~~~~~~~~
 
 
@@ -861,7 +858,7 @@ of DNS-stored encryption keys (#28 and #94)
 
 ## Since draft-foudil-securitytxt-10
 - Changes addressing IESG feedback
-- Removed languages regarding file systems (#201)
+- Removed language regarding file systems (#201)
 
 Full list of changes can be viewed via the IETF document tracker:
 https://tools.ietf.org/html/draft-foudil-securitytxt

--- a/draft-foudil-securitytxt.txt
+++ b/draft-foudil-securitytxt.txt
@@ -5,8 +5,8 @@
 Network Working Group                                          E. Foudil
 Internet-Draft                                                          
 Intended status: Informational                           Y. Shafranovich
-Expires: 28 August 2021                         Nightwatch Cybersecurity
-                                                        24 February 2021
+Expires: 29 August 2021                         Nightwatch Cybersecurity
+                                                        25 February 2021
 
 
        A File Format to Aid in Security Vulnerability Disclosure
@@ -36,7 +36,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on 28 August 2021.
+   This Internet-Draft will expire on 29 August 2021.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 1]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 1]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 2]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 2]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -165,7 +165,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 3]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 3]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -221,7 +221,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 4]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 4]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -277,7 +277,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 5]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 5]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -333,7 +333,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 6]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 6]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -389,7 +389,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 7]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 7]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -445,7 +445,7 @@ Encryption: dns:5d2d37ab76d47d36._openpgpkey.example.com?type=OPENPGPKEY
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 8]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 8]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -501,7 +501,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                 [Page 9]
+Foudil & Shafranovich    Expires 29 August 2021                 [Page 9]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -557,7 +557,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 10]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 10]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -592,9 +592,6 @@ Internet-Draft                security.txt                 February 2021
    # This security.txt file applies to IPv6 address of 2001:db8:8:4::2.
    https://[2001:db8:8:4::2]/.well-known/security.txt
 
-   # This file applies to the /example/folder1 directory and subfolders.
-   /example/folder1/security.txt
-
 5.  File Format Description and ABNF Grammar
 
    The expected file format of the security.txt file is plain text (MIME
@@ -610,17 +607,17 @@ Internet-Draft                security.txt                 February 2021
 
   sign-header      =  < headers and line from section 7 of [RFC4880] >
 
+  sign-footer      =  < OpenPGP signature from section 7 of [RFC4880] >
+
+  unsigned         =  *line (contact-field eol)
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 11]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 11]
 
 Internet-Draft                security.txt                 February 2021
 
 
-  sign-footer      =  < OpenPGP signature from section 7 of [RFC4880] >
-
-  unsigned         =  *line (contact-field eol)
                       *line (expires-field eol)
                       *line [lang-field eol] *line
                       ; order of fields within the file is not important
@@ -667,14 +664,15 @@ Internet-Draft                security.txt                 February 2021
 
   ext-field        =  field-name fs SP unstructured
 
+  field-name       =  < imported from section 3.6.8 of [RFC5322] >
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 12]
+
+
+Foudil & Shafranovich    Expires 29 August 2021                [Page 12]
 
 Internet-Draft                security.txt                 February 2021
 
-
-  field-name       =  < imported from section 3.6.8 of [RFC5322] >
 
   unstructured     =  < imported from section 3.2.5 of [RFC5322] >
 
@@ -725,7 +723,9 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 13]
+
+
+Foudil & Shafranovich    Expires 29 August 2021                [Page 13]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -781,7 +781,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 14]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 14]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -837,7 +837,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 15]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 15]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -893,7 +893,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 16]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 16]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -949,7 +949,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 17]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 17]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1005,7 +1005,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 18]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 18]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1061,7 +1061,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 19]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 19]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1117,7 +1117,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 20]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 20]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1173,7 +1173,7 @@ Internet-Draft                security.txt                 February 2021
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 21]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 21]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1229,7 +1229,7 @@ B.1.  Since draft-foudil-securitytxt-00
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 22]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 22]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1285,7 +1285,7 @@ B.3.  Since draft-foudil-securitytxt-02
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 23]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 23]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1341,7 +1341,7 @@ B.5.  Since draft-foudil-securitytxt-04
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 24]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 24]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1397,7 +1397,7 @@ B.9.  Since draft-foudil-securitytxt-08
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 25]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 25]
 
 Internet-Draft                security.txt                 February 2021
 
@@ -1420,7 +1420,7 @@ B.11.  Since draft-foudil-securitytxt-10
 
    *  Changes addressing IESG feedback
 
-   *  Removed languages regarding file systems (#201)
+   *  Removed language regarding file systems (#201)
 
    Full list of changes can be viewed via the IETF document tracker:
    https://tools.ietf.org/html/draft-foudil-securitytxt
@@ -1453,4 +1453,4 @@ Authors' Addresses
 
 
 
-Foudil & Shafranovich    Expires 28 August 2021                [Page 26]
+Foudil & Shafranovich    Expires 29 August 2021                [Page 26]


### PR DESCRIPTION
Further to #201, further to https://github.com/securitytxt/security-txt/commit/5d8235d61238753629283b6f5460f09699de1cf6

This PR removes the following lines:
> ```
> # This file applies to the /example/folder1 directory and subfolders.
> /example/folder1/security.txt
> ```

No entry in the change log is made because there is already a corresponding one to removing all mention of security.txt usage in file systems. However, I fixed a typo in that change log entry.

Viewing just the markdown version provides a nicer diff.